### PR TITLE
v6: apply_edition returns the default edition now (XCPNG-3294)

### DIFF
--- a/lib/v6.ml
+++ b/lib/v6.ml
@@ -1,8 +1,10 @@
 module L = Debug.Make (struct let name = __MODULE__ end)
 
-let editions =
-  let open V6_interface in
-  [{title= "xcp-ng"; official_title= "xcp-ng"; code= "xcp-ng"; order= 100}]
+let default_edition =
+  V6_interface.
+    {title= "xcp-ng"; official_title= "xcp-ng"; code= "xcp-ng"; order= 100}
+
+let editions = [default_edition]
 (* TODO: real editions *)
 
 let unsupported_features = Features.[Corosync]
@@ -151,14 +153,15 @@ module Experimental = Custom (struct
 end)
 
 (* Allows to apply edition without reading from the filesystem *)
-let apply_edition_test _dbg edition _params =
+let apply_edition_test _dbg _edition _params =
   {
-    V6_interface.edition_name= edition
+    V6_interface.edition_name= default_edition.title
   ; xapi_params
   ; additional_params= Additional.params
   ; experimental_features= []
   }
 
+(* The default edition is hard-coded *)
 let apply_edition dbg edition params =
   {
     (apply_edition_test dbg edition params) with

--- a/lib/v6.ml
+++ b/lib/v6.ml
@@ -150,12 +150,19 @@ module Experimental = Custom (struct
   let root = "/etc/xcp/experimental-features.d"
 end)
 
-let apply_edition _dbg edition _params =
+(* Allows to apply edition without reading from the filesystem *)
+let apply_edition_test _dbg edition _params =
   {
     V6_interface.edition_name= edition
   ; xapi_params
   ; additional_params= Additional.params
-  ; experimental_features= Experimental.list ()
+  ; experimental_features= []
+  }
+
+let apply_edition dbg edition params =
+  {
+    (apply_edition_test dbg edition params) with
+    experimental_features= Experimental.list ()
   }
 
 let get_editions _dbg = editions

--- a/lib/v6.mli
+++ b/lib/v6.mli
@@ -20,3 +20,6 @@ module type Directory = sig val root : string end
 
 module Custom : functor (D : Directory) -> sig
   val list : unit -> (string * bool) list end
+
+val apply_edition_test :
+  string -> string -> (string * string) list -> V6_interface.edition_info

--- a/lib/v6_test.ml
+++ b/lib/v6_test.ml
@@ -15,4 +15,19 @@ let test_additional_features =
 
 let feature_tests = ("Additional features", [test_additional_features])
 
-let () = Alcotest.run "XCP-ng V6 library" [feature_tests]
+let test_editions =
+  let test () =
+    let open V6_interface in
+    let edition = "" in
+    let expected =
+      Xcp_ng.V6.get_editions "" |> List.hd |> function {title; _} -> title
+    in
+    let {edition_name; _} = Xcp_ng.V6.apply_edition_test "dbg" edition [] in
+    let msg = Printf.sprintf "Edition must be '%s'" expected in
+    Alcotest.(check string) msg expected edition_name
+  in
+  ("Always apply the edition 'xcp-ng'", `Quick, test)
+
+let edition_tests = ("Editions", [test_editions])
+
+let () = Alcotest.run "XCP-ng V6 library" [feature_tests; edition_tests]


### PR DESCRIPTION
Xapi uses the name of the returned editions to do checks on pool
operations, like pool join. Make sure the name matches the one from the
default edition, since there's only one

Fixes 92aa8818149d2af4fd844d52838aa17f705c8707
